### PR TITLE
main.cpp: add a missing <map> header

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <ftxui/component/screen_interactive.hpp> // for ScreenInteractive
 #include <ftxui/screen/color.hpp>
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
There was no error with gcc, but clang requires the header being added.
```
In file included from /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:21:
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/player.cpp:451:15: warning: 14 enumeration values not handled in switch: 'MPV_EVENT_NONE', 'MPV_EVENT_SHUTDOWN', 'MPV_EVENT_LOG_MESSAGE'... [-Wswitch]
      switch (event->event_id) {
              ^~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/player.cpp:451:15: note: add missing switch cases
      switch (event->event_id) {
              ^
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:79:6: error: no template named 'map' in namespace 'std'; did you mean 'max'?
std::map<std::string, std::vector<std::string>> ascii_art = {
~~~~~^~~
     max
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/c++/v1/__algorithm/max.h:31:1: note: 'max' declared here
max(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp)
^
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:79:6: error: a type specifier is required for all declarations
std::map<std::string, std::vector<std::string>> ascii_art = {
     ^
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:79:6: error: template specialization requires 'template<>'
std::map<std::string, std::vector<std::string>> ascii_art = {
     ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
template<> 
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:79:6: error: no variable template matches specialization; did you mean to use 'max' as function template instead?
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:79:48: error: expected ';' after top level declarator
std::map<std::string, std::vector<std::string>> ascii_art = {
                                               ^
                                               ;
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_audio_tuisic/tuisic/work/tuisic-stable/src/main.cpp:106:10: error: use of undeclared identifier 'ascii_art'
  return ascii_art[genre];
         ^
1 warning and 6 errors generated.
```